### PR TITLE
Add second deposit tx type that doesn't include the mint field in the tx hash

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -78,7 +78,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
-	if tx.Type() == types.DepositTxType {
+	if tx.IsDepositTx() {
 		return core.ErrTxTypeNotSupported
 	}
 	if opts.Config.IsOptimism() && tx.Type() == types.BlobTxType {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -24,7 +24,10 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-const DepositTxType = 0x7E
+const (
+	DepositTxType   = 0x7E // Legacy deposits (pre-Bluebird)
+	DepositTxV2Type = 0x7D // Bluebird deposits (exclude Mint from hash)
+)
 
 type DepositTx struct {
 	// SourceHash uniquely identifies the source of the deposit

--- a/core/types/deposit_tx_v2.go
+++ b/core/types/deposit_tx_v2.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+// DepositTxV2 embeds DepositTx to inherit all fields and methods
+type DepositTxV2 struct{ DepositTx }
+
+// txType identifies this as a V2 deposit
+func (tx *DepositTxV2) txType() byte { return DepositTxV2Type }
+
+// copy creates a deep copy and returns the correct concrete type
+func (tx *DepositTxV2) copy() TxData {
+	depCopy := tx.DepositTx.copy().(*DepositTx) // deep-copy from the embedded value
+	return &DepositTxV2{DepositTx: *depCopy}
+}

--- a/core/types/deposit_tx_v2_test.go
+++ b/core/types/deposit_tx_v2_test.go
@@ -1,0 +1,332 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestDepositTxV2Hash(t *testing.T) {
+	// Create two identical transactions, one V1 and one V2
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	
+	v1 := &Transaction{inner: &DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}
+	
+	v2 := &Transaction{inner: &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}}
+	
+	// V1 and V2 should have different hashes
+	hash1 := v1.Hash()
+	hash2 := v2.Hash()
+	
+	if hash1 == hash2 {
+		t.Errorf("V1 and V2 deposit transactions should have different hashes, got: %s", hash1.Hex())
+	}
+	
+	// Create V2 without Mint (but same IsSystemTransaction)
+	v2NoMint := &Transaction{inner: &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                nil,
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,  // Same as original
+		Data:                []byte("test data"),
+	}}}
+	
+	// V2 with Mint should hash the same as V2 without Mint
+	hash2NoMint := v2NoMint.Hash()
+	
+	if hash2 != hash2NoMint {
+		t.Errorf("V2 deposit transactions should have same hash regardless of Mint\ngot: %s\nwant: %s", hash2.Hex(), hash2NoMint.Hex())
+	}
+	
+	// Create V2 with different IsSystemTransaction - should have different hash
+	v2DiffSystem := &Transaction{inner: &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: false,  // Different from original
+		Data:                []byte("test data"),
+	}}}
+	
+	hash2DiffSystem := v2DiffSystem.Hash()
+	
+	if hash2 == hash2DiffSystem {
+		t.Errorf("V2 deposit transactions with different IsSystemTransaction should have different hashes")
+	}
+}
+
+func TestDepositTxV2Type(t *testing.T) {
+	tx := &Transaction{inner: &DepositTxV2{}}
+	
+	if tx.Type() != DepositTxV2Type {
+		t.Errorf("DepositTxV2 type mismatch: got %d, want %d", tx.Type(), DepositTxV2Type)
+	}
+	
+	if !tx.IsDepositTx() {
+		t.Error("DepositTxV2 should return true for IsDepositTx()")
+	}
+}
+
+func TestDepositTxV2Copy(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	original := &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}
+	
+	// Test copy
+	copied := original.copy()
+	copiedV2, ok := copied.(*DepositTxV2)
+	if !ok {
+		t.Fatal("copy() should return *DepositTxV2")
+	}
+	
+	// Verify deep copy
+	if copiedV2.Mint == original.Mint {
+		t.Error("Mint should be deep copied")
+	}
+	if copiedV2.Value == original.Value {
+		t.Error("Value should be deep copied")
+	}
+	
+	// Verify values are equal
+	if copiedV2.Mint.Cmp(original.Mint) != 0 {
+		t.Error("Copied Mint value mismatch")
+	}
+	if copiedV2.Value.Cmp(original.Value) != 0 {
+		t.Error("Copied Value mismatch")
+	}
+}
+
+func TestDepositTxV2Marshalling(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	
+	// Test transaction without nonce
+	tx1 := &Transaction{inner: &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}}
+	
+	// Marshal to JSON
+	jsonData, err := tx1.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal DepositTxV2: %v", err)
+	}
+	
+	// Unmarshal back
+	var tx2 Transaction
+	if err := tx2.UnmarshalJSON(jsonData); err != nil {
+		t.Fatalf("Failed to unmarshal DepositTxV2: %v", err)
+	}
+	
+	// Verify type
+	if tx2.Type() != DepositTxV2Type {
+		t.Errorf("Unmarshalled type mismatch: got %d, want %d", tx2.Type(), DepositTxV2Type)
+	}
+	
+	// Verify values
+	v2, ok := tx2.inner.(*DepositTxV2)
+	if !ok {
+		t.Fatal("Unmarshalled transaction is not DepositTxV2")
+	}
+	
+	if v2.SourceHash != common.HexToHash("0xdeadbeef") {
+		t.Error("SourceHash mismatch after unmarshalling")
+	}
+	if v2.From != addr {
+		t.Error("From address mismatch after unmarshalling")
+	}
+	if v2.Mint.Cmp(big.NewInt(1000)) != 0 {
+		t.Error("Mint value mismatch after unmarshalling")
+	}
+}
+
+func TestDepositTxV2WithNonce(t *testing.T) {
+	// Create JSON with nonce
+	jsonStr := `{
+		"type": "0x7d",
+		"sourceHash": "0x000000000000000000000000000000000000000000000000000000000000dead",
+		"from": "0x1234567890123456789012345678901234567890",
+		"to": "0x1234567890123456789012345678901234567890",
+		"mint": "0x3e8",
+		"value": "0x7d0",
+		"gas": "0xc350",
+		"isSystemTx": true,
+		"input": "0x74657374",
+		"nonce": "0x42",
+		"hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+	}`
+	
+	var tx Transaction
+	if err := json.Unmarshal([]byte(jsonStr), &tx); err != nil {
+		t.Fatalf("Failed to unmarshal DepositTxV2 with nonce: %v", err)
+	}
+	
+	// Should be wrapped with nonce
+	wrapper, ok := tx.inner.(*depositTxV2WithNonce)
+	if !ok {
+		t.Fatal("Transaction with nonce should be wrapped in depositTxV2WithNonce")
+	}
+	
+	if wrapper.EffectiveNonce != 0x42 {
+		t.Errorf("Nonce mismatch: got %d, want %d", wrapper.EffectiveNonce, 0x42)
+	}
+	
+	// Verify it still identifies as deposit
+	if !tx.IsDepositTx() {
+		t.Error("Transaction with nonce should still return true for IsDepositTx()")
+	}
+}
+
+func TestDepositTxV2RLP(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	
+	tx := &DepositTxV2{DepositTx{
+		SourceHash:          common.HexToHash("0xdeadbeef"),
+		From:                addr,
+		To:                  &addr,
+		Mint:                big.NewInt(1000),
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}
+	
+	// Encode
+	var buf bytes.Buffer
+	if err := tx.encode(&buf); err != nil {
+		t.Fatalf("Failed to encode DepositTxV2: %v", err)
+	}
+	
+	// Decode
+	var decoded DepositTxV2
+	if err := decoded.decode(buf.Bytes()); err != nil {
+		t.Fatalf("Failed to decode DepositTxV2: %v", err)
+	}
+	
+	// Verify values match
+	if decoded.SourceHash != tx.SourceHash {
+		t.Error("SourceHash mismatch after RLP round trip")
+	}
+	if decoded.From != tx.From {
+		t.Error("From mismatch after RLP round trip")
+	}
+	if decoded.Mint.Cmp(tx.Mint) != 0 {
+		t.Error("Mint mismatch after RLP round trip")
+	}
+}
+
+func TestDepositTxV2HelperMethods(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	sourceHash := common.HexToHash("0xdeadbeef")
+	mint := big.NewInt(1000)
+	
+	tx := &Transaction{inner: &DepositTxV2{DepositTx{
+		SourceHash:          sourceHash,
+		From:                addr,
+		To:                  &addr,
+		Mint:                mint,
+		Value:               big.NewInt(2000),
+		Gas:                 50000,
+		IsSystemTransaction: true,
+		Data:                []byte("test data"),
+	}}}
+	
+	// Test SourceHash()
+	if tx.SourceHash() != sourceHash {
+		t.Error("SourceHash() mismatch")
+	}
+	
+	// Test Mint()
+	if tx.Mint().Cmp(mint) != 0 {
+		t.Error("Mint() mismatch")
+	}
+	
+	// Test RollupCostData()
+	costData := tx.RollupCostData()
+	if costData != (RollupCostData{}) {
+		t.Error("RollupCostData() should return zero value for deposit transactions")
+	}
+}
+
+func TestDepositTxV2Signing(t *testing.T) {
+	tx := &Transaction{inner: &DepositTxV2{}}
+	signer := NewLondonSigner(big.NewInt(1))
+	
+	// Test that Sender works with V2
+	addr, err := signer.Sender(tx)
+	if err != nil {
+		t.Fatalf("Failed to get sender: %v", err)
+	}
+	if addr != (common.Address{}) {
+		t.Error("Sender should return zero address for unsigned deposit")
+	}
+	
+	// Test that SignatureValues returns error
+	_, _, _, err = signer.SignatureValues(tx, nil)
+	if err == nil {
+		t.Error("SignatureValues should return error for deposit transactions")
+	}
+	
+	// Test that Hash panics
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Hash should panic for deposit transactions")
+		}
+	}()
+	signer.Hash(tx)
+}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -256,7 +256,7 @@ func (r *Receipt) EncodeRLP(w io.Writer) error {
 func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case DepositTxType:
+	case DepositTxType, DepositTxV2Type:
 		withNonce := &depositReceiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.DepositNonce, r.DepositReceiptVersion}
 		return rlp.Encode(w, withNonce)
 	default:
@@ -337,7 +337,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		}
 		r.Type = b[0]
 		return r.setFromRLP(data)
-	case DepositTxType:
+	case DepositTxType, DepositTxV2Type:
 		var data depositReceiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -504,7 +504,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	switch r.Type {
 	case AccessListTxType, DynamicFeeTxType, BlobTxType:
 		rlp.Encode(w, data)
-	case DepositTxType:
+	case DepositTxType, DepositTxV2Type:
 		if r.DepositReceiptVersion != nil {
 			// post-canyon receipt hash computation update
 			depositData := &depositReceiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, r.Bloom, r.Logs, r.DepositNonce, r.DepositReceiptVersion}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -213,6 +213,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(BlobTx)
 	case DepositTxType:
 		inner = new(DepositTx)
+	case DepositTxV2Type:
+		inner = new(DepositTxV2)
 	default:
 		return nil, ErrTxTypeNotSupported
 	}
@@ -334,7 +336,10 @@ func (tx *Transaction) To() *common.Address {
 // e.g. a user deposit event, or a L1 info deposit included in a specific L2 block height.
 // Non-deposit transactions return a zeroed hash.
 func (tx *Transaction) SourceHash() common.Hash {
-	if dep, ok := tx.inner.(*DepositTx); ok {
+	switch dep := tx.inner.(type) {
+	case *DepositTx:
+		return dep.SourceHash
+	case *DepositTxV2:
 		return dep.SourceHash
 	}
 	return common.Hash{}
@@ -343,7 +348,10 @@ func (tx *Transaction) SourceHash() common.Hash {
 // Mint returns the ETH to mint in the deposit tx.
 // This returns nil if there is nothing to mint, or if this is not a deposit tx.
 func (tx *Transaction) Mint() *big.Int {
-	if dep, ok := tx.inner.(*DepositTx); ok {
+	switch dep := tx.inner.(type) {
+	case *DepositTx:
+		return dep.Mint
+	case *DepositTxV2:
 		return dep.Mint
 	}
 	return nil
@@ -351,7 +359,8 @@ func (tx *Transaction) Mint() *big.Int {
 
 // IsDepositTx returns true if the transaction is a deposit tx type.
 func (tx *Transaction) IsDepositTx() bool {
-	return tx.Type() == DepositTxType
+	t := tx.Type()
+	return t == DepositTxType || t == DepositTxV2Type
 }
 
 // IsSystemTx returns true for deposits that are system transactions. These transactions
@@ -372,7 +381,7 @@ func (tx *Transaction) Cost() *big.Int {
 
 // RollupCostData caches the information needed to efficiently compute the data availability fee
 func (tx *Transaction) RollupCostData() RollupCostData {
-	if tx.Type() == DepositTxType {
+	if tx.IsDepositTx() {
 		return RollupCostData{}
 	}
 	if v := tx.rollupCostData.Load(); v != nil {
@@ -418,7 +427,7 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
-	if tx.Type() == DepositTxType {
+	if tx.IsDepositTx() {
 		return new(big.Int), nil
 	}
 	if baseFee == nil {
@@ -564,18 +573,27 @@ func (tx *Transaction) Time() time.Time {
 
 // Hash returns the transaction hash.
 func (tx *Transaction) Hash() common.Hash {
-	if hash := tx.hash.Load(); hash != nil {
-		return *hash
+	if h := tx.hash.Load(); h != nil {
+		return *h
 	}
 
-	var h common.Hash
-	if tx.Type() == LegacyTxType {
-		h = rlpHash(tx.inner)
-	} else {
-		h = prefixedRlpHash(tx.Type(), tx.inner)
+	var out common.Hash
+	switch tx.Type() {
+	case LegacyTxType:
+		out = rlpHash(tx.inner)
+
+	case DepositTxV2Type:
+		// Copy the transaction and zero out Mint field only
+		d := *(tx.inner.(*DepositTxV2))
+		d.Mint = nil
+		out = prefixedRlpHash(tx.Type(), &d)
+
+	default:
+		out = prefixedRlpHash(tx.Type(), tx.inner)
 	}
-	tx.hash.Store(&h)
-	return h
+
+	tx.hash.Store(&out)
+	return out
 }
 
 // Size returns the true encoded storage size of the transaction, either by encoding

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -341,6 +341,10 @@ func (tx *Transaction) SourceHash() common.Hash {
 		return dep.SourceHash
 	case *DepositTxV2:
 		return dep.SourceHash
+	case *depositTxWithNonce:
+		return dep.SourceHash
+	case *depositTxV2WithNonce:
+		return dep.SourceHash
 	}
 	return common.Hash{}
 }
@@ -352,6 +356,10 @@ func (tx *Transaction) Mint() *big.Int {
 	case *DepositTx:
 		return dep.Mint
 	case *DepositTxV2:
+		return dep.Mint
+	case *depositTxWithNonce:
+		return dep.Mint
+	case *depositTxV2WithNonce:
 		return dep.Mint
 	}
 	return nil
@@ -584,7 +592,15 @@ func (tx *Transaction) Hash() common.Hash {
 
 	case DepositTxV2Type:
 		// Copy the transaction and zero out Mint field only
-		d := *(tx.inner.(*DepositTxV2))
+		var d DepositTxV2
+		switch inner := tx.inner.(type) {
+		case *DepositTxV2:
+			d = *inner
+		case *depositTxV2WithNonce:
+			d = inner.DepositTxV2
+		default:
+			panic(fmt.Sprintf("expected DepositTxV2 or depositTxV2WithNonce, got %T", tx.inner))
+		}
 		d.Mint = nil
 		out = prefixedRlpHash(tx.Type(), &d)
 

--- a/eth/downloader/receiptreference.go
+++ b/eth/downloader/receiptreference.go
@@ -112,7 +112,7 @@ func correctReceipts(receipts types.Receipts, transactions types.Transactions, b
 			continue
 		}
 		// break as soon as a non deposit is found
-		if r.Type != types.DepositTxType {
+		if r.Type != types.DepositTxType && r.Type != types.DepositTxV2Type {
 			break
 		}
 		// ignore any transactions from the system address

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1510,7 +1510,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	}
 
 	switch tx.Type() {
-	case types.DepositTxType:
+	case types.DepositTxType, types.DepositTxV2Type:
 		srcHash := tx.SourceHash()
 		isSystemTx := tx.IsSystemTx()
 		result.SourceHash = &srcHash
@@ -1618,7 +1618,7 @@ func newRPCTransactionFromBlockIndex(ctx context.Context, b *types.Block, index 
 }
 
 func depositTxReceipt(ctx context.Context, blockHash common.Hash, index uint64, backend Backend, tx *types.Transaction) *types.Receipt {
-	if tx.Type() != types.DepositTxType {
+	if !tx.IsDepositTx() {
 		return nil
 	}
 	receipts, err := backend.GetReceipts(ctx, blockHash)

--- a/params/config.go
+++ b/params/config.go
@@ -381,6 +381,9 @@ type ChainConfig struct {
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 
+	// Bluebird fork
+	BluebirdTime *uint64 `json:"bluebirdTime,omitempty"` // Bluebird fork time (nil = no fork, 0 = already on bluebird)
+
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
 	TerminalTotalDifficulty *big.Int `json:"terminalTotalDifficulty,omitempty"`
@@ -543,6 +546,9 @@ func (c *ChainConfig) Description() string {
 	if c.InteropTime != nil {
 		banner += fmt.Sprintf(" - Interop:                     @%-10v\n", *c.InteropTime)
 	}
+	if c.BluebirdTime != nil {
+		banner += fmt.Sprintf(" - Bluebird:                    @%-10v\n", *c.BluebirdTime)
+	}
 	return banner
 }
 
@@ -682,6 +688,11 @@ func (c *ChainConfig) IsHolocene(time uint64) bool {
 
 func (c *ChainConfig) IsInterop(time uint64) bool {
 	return isTimestampForked(c.InteropTime, time)
+}
+
+// IsBluebird returns whether time is either equal to the Bluebird fork time or greater.
+func (c *ChainConfig) IsBluebird(time uint64) bool {
+	return isTimestampForked(c.BluebirdTime, time)
 }
 
 // IsOptimism returns whether the node is an optimism node or not.
@@ -907,6 +918,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkTimestampIncompatible(c.InteropTime, newcfg.InteropTime, headTimestamp, genesisTimestamp) {
 		return newTimestampCompatError("Interop fork timestamp", c.InteropTime, newcfg.InteropTime)
+	}
+	if isForkTimestampIncompatible(c.BluebirdTime, newcfg.BluebirdTime, headTimestamp, genesisTimestamp) {
+		return newTimestampCompatError("Bluebird fork timestamp", c.BluebirdTime, newcfg.BluebirdTime)
 	}
 	return nil
 }


### PR DESCRIPTION
This enables more complicated / nuanced FCT minting without removing the ability to calculate the tx hash.